### PR TITLE
Synchronized Code profiles via safe symlink seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Both work. Both are fiddly to set up and easy to mess up. This tool automates th
 - Generating a real macOS `.app` launcher you can drag to the Dock
 - Copying the Claude icon onto the launcher so it's visually distinct
 - Adding a properly quoted shell alias to the right rc file (zsh, bash, fish)
-- Seeding new Code profiles from your existing `~/.claude` so plugins and MCP servers carry over (without leaking auth)
+- Seeding new Code profiles from your existing `~/.claude` — copy a snapshot, or symlink selected items so they stay in sync (never auth)
 - Tracking everything in a registry so you can list, status-check, and cleanly remove profiles
 
 ## Install
@@ -85,7 +85,14 @@ Claude Code (the terminal CLI) honors the `CLAUDE_CONFIG_DIR` environment variab
 
 Authentication is the interesting bit. Claude Code stores its OAuth token in macOS Keychain, keyed by a SHA-256 hash of the active `CLAUDE_CONFIG_DIR`. Different config dir, different keychain entry, completely separate session. You can copy a config folder around without leaking auth.
 
-This means you can seed a new Code profile from your existing `~/.claude` (carrying over skills, plugins, and MCP servers) and the new profile will still ask you to log in fresh. The wizard offers this by default.
+This means you can seed a new Code profile from your existing `~/.claude` and the new profile will still ask you to log in fresh.
+
+The wizard gives you two ways to do this:
+
+- **Isolated** (default) — a standalone config. Optionally copy a one-time snapshot of `~/.claude` into it (skills, plugins, settings), after which the two are fully independent. Or start empty.
+- **Synchronized** — pick items to **symlink** back to `~/.claude`, so they stay live-shared. Install a skill or plugin under one profile and it shows up in both.
+
+Both modes use the same **blocklist**: everything under `~/.claude` is included *except* auth/identity files (`.claude.json`, `.credentials.json`, and anything matching credential/token/secret/oauth/key/`.env` patterns) and instance-local noise (caches, logs, `statsig`, `daemon*`, `shell-snapshots`). So your own custom directories come along too, but your login can never leak. For symlink mode the exclusion is enforced both in the picker and again when the links are created; for copy mode the snapshot is pruned to the same safe set. Note that if you keep an API key inside `settings.json` or an MCP config and choose to share that file, the key travels with it — only the Keychain login is guaranteed separate.
 
 ## Commands
 
@@ -99,7 +106,7 @@ Interactive wizard. Walks through:
 4. Where to save the launcher .app (Desktop only)
 5. Whether to copy the Claude icon onto the launcher (Desktop only)
 6. The shell alias name (Code only)
-7. Whether to seed the new Code profile from your existing `~/.claude` (Code only)
+7. How to seed the new Code profile (Code only): isolated (copy a snapshot or start empty), or synchronized (symlink selected items from `~/.claude`, auth excluded)
 
 Then prints a plan, asks for confirmation, and applies.
 

--- a/src/code.js
+++ b/src/code.js
@@ -50,6 +50,62 @@ export function defaultConfigDirFor(name) {
 // profile from an existing setup.
 export const DEFAULT_CLAUDE_CONFIG_DIR = path.join(HOME, ".claude");
 
+// Sharing model: BLOCKLIST, not allowlist. Everything under ~/.claude is
+// shareable EXCEPT auth/identity (the hard security boundary) and instance-
+// local noise (caches, logs — sharing them just causes conflicts). This lets
+// a user share their own custom dirs/files too, without us enumerating them.
+//
+// The auth exclusions are the security-critical part and are re-enforced at
+// the sink (symlinkSelected), so login can never leak no matter what is passed.
+const NEVER_SHARE_EXACT = new Set([
+  ".claude.json", // oauthAccount identity + per-project trust
+  ".credentials.json", // the login itself (Linux/Windows file form)
+  "credentials.json",
+  "auth.json",
+  // instance-local / cache / noise: sharing these causes conflicts, not value
+  "statsig", "backups", "shell-snapshots", "debug", "ide", "jobs",
+  "cache", "paste-cache", "telemetry", ".DS_Store",
+]);
+
+// Patterns for names we can't enumerate (a future .credentials-v2.json, an
+// api-token file, per-instance caches). The auth/identity patterns are the
+// security-critical ones and are matched UNBOUNDED on purpose: for that class
+// we prefer a rare false-positive (a safe file wrongly hidden from the picker)
+// over ever sharing a credential. Erring closed is the point of the boundary.
+const NEVER_SHARE_PATTERNS = [
+  // auth / identity — fail closed
+  /credential/i, /token/i, /secret/i, /password/i, /passwd/i,
+  /api[-_]?key/i, /cookie/i, /keychain/i,
+  /\.pem$/i, /\.key$/i, /\.jwt$/i, /id_(rsa|dsa|ecdsa|ed25519)/i,
+  /(^|[.-])oauth([.-]|$)/i, /(^|[.-])auth([.-]|$)/i,
+  /(^|[.-])account([.-]|$)/i, /(^|[.-])identity([.-]|$)/i,
+  /^\.env($|\.)/i,
+  // instance-local noise — not security, just avoids junk/conflicts
+  /cache/i, /-stats\.json$/i, /^daemon/i, /\.log$/i,
+];
+
+// True if `name` (a single basename from ~/.claude) is safe to share. Rejects
+// path separators and dot-segments so a crafted name can't escape the source
+// or profile dir through the symlink path.
+export function isShareable(name) {
+  if (!name || name === "." || name === "..") return false;
+  if (name.includes("/") || name.includes("\\")) return false;
+  if (NEVER_SHARE_EXACT.has(name)) return false;
+  return !NEVER_SHARE_PATTERNS.some((re) => re.test(name));
+}
+
+// The shareable entries actually present under sourceDir. Populates the
+// interactive picker — a user's own custom items show up here too.
+export function shareableItemsIn(sourceDir = DEFAULT_CLAUDE_CONFIG_DIR) {
+  let entries;
+  try {
+    entries = fs.readdirSync(sourceDir);
+  } catch {
+    return [];
+  }
+  return entries.filter(isShareable).sort();
+}
+
 export function defaultAliasNameFor(name) {
   // Human-friendly alias users will actually type.
   // We deliberately don't reuse the bare `claude` command since that's
@@ -60,17 +116,25 @@ export function defaultAliasNameFor(name) {
 
 // ---- Directory setup -----------------------------------------------------
 
-export function ensureConfigDir(configDir, { seedFromDefault } = {}) {
+// seedMode:
+//   "copy"    - cp -R ~/.claude into the new dir (point-in-time snapshot)
+//   "symlink" - symlink the selected safe items from ~/.claude (live share)
+//   "empty"   - just create an empty dir (default when there's no ~/.claude)
+export function ensureConfigDir(
+  configDir,
+  { seedMode = "empty", seedItems } = {}
+) {
   // If the directory already exists, we leave it alone. The user is
   // probably re-running the wizard after partial completion, and we do
   // not want to clobber state they may have intentionally put there.
   if (fs.existsSync(configDir)) return false;
 
-  if (seedFromDefault && fs.existsSync(DEFAULT_CLAUDE_CONFIG_DIR)) {
+  const hasDefault = fs.existsSync(DEFAULT_CLAUDE_CONFIG_DIR);
+
+  if (seedMode === "copy" && hasDefault) {
     // Copy the user's existing ~/.claude into the new dir. This carries
-    // over skills, plugins, MCP server config, slash commands, and any
-    // CLAUDE.md they have at the user level. Auth stays in Keychain so
-    // it won't follow.
+    // over skills, plugins, slash commands, and any CLAUDE.md they have at
+    // the user level. Auth stays in Keychain so it won't follow.
     //
     // We use `cp -R` rather than fs.cpSync because cp handles macOS
     // metadata (extended attrs, resource forks) more faithfully and
@@ -82,21 +146,62 @@ export function ensureConfigDir(configDir, { seedFromDefault } = {}) {
       configDir,
     ]);
 
-    // Wipe anything that looks like a credential file inside the seeded
-    // copy. Claude Code's auth lives in Keychain, not on disk, so this is
-    // mostly belt-and-suspenders for older installs and project-level
-    // .credentials.json files. Better safe than carrying over a stale
-    // token that confuses login.
+    // Copy the same safe set as symlink mode: prune anything the blocklist
+    // excludes (auth/identity + cache/instance noise) from the snapshot, so
+    // both modes honor one source of truth and a copied profile can never
+    // retain a credential, token, or key file.
+    for (const name of fs.readdirSync(configDir)) {
+      if (!isShareable(name)) {
+        fs.rmSync(path.join(configDir, name), { recursive: true, force: true });
+      }
+    }
+    // Belt-and-suspenders for legacy on-disk credential files.
     cleanCredentialsFromDir(configDir);
+  } else if (seedMode === "symlink" && hasDefault) {
+    fs.mkdirSync(configDir, { recursive: true });
+    symlinkSelected(configDir, seedItems ?? shareableItemsIn());
   } else {
     fs.mkdirSync(configDir, { recursive: true });
   }
   return true;
 }
 
+// Symlink each selected item from ~/.claude into configDir. The profile then
+// shares that live data with the root instead of holding a stale copy.
+//
+// Security boundary: every name is re-checked with isShareable(), so even if a
+// caller passes an auth file, a cache dir, or a traversal name (../x), it is
+// skipped. Auth can never be symlinked through this path.
+export function symlinkSelected(configDir, items, sourceDir = DEFAULT_CLAUDE_CONFIG_DIR) {
+  const linked = [];
+  for (const name of items ?? []) {
+    if (!isShareable(name)) {
+      warn(`Refusing to symlink "${name}" (auth/identity or unsafe name).`);
+      continue;
+    }
+    const src = path.join(sourceDir, name);
+    if (!fs.existsSync(src)) continue; // nothing to link
+    const dst = path.join(configDir, name);
+    // Only clear a prior symlink so re-linking is idempotent. Never recursively
+    // delete a real file/dir a caller may have placed here — if one exists,
+    // symlinkSync throws EEXIST and we fail loud rather than destroy data.
+    try {
+      if (fs.lstatSync(dst).isSymbolicLink()) fs.rmSync(dst);
+    } catch {
+      // dst doesn't exist — nothing to clear.
+    }
+    fs.symlinkSync(src, dst);
+    linked.push(name);
+  }
+  return linked;
+}
+
 function cleanCredentialsFromDir(dir) {
-  // Remove known credential filenames if the user had any stashed locally.
+  // Remove known credential/identity filenames from a copied profile. Auth
+  // lives in Keychain, but a copied .claude.json carries oauthAccount identity
+  // and per-project trust, and older installs may have on-disk credential files.
   const candidates = [
+    path.join(dir, ".claude.json"),
     path.join(dir, ".credentials.json"),
     path.join(dir, "credentials.json"),
     path.join(dir, "auth.json"),
@@ -136,17 +241,21 @@ export function removeAlias(aliasName) {
 
 // ---- Top-level orchestration ---------------------------------------------
 
-export function setupCode({ name, configDir, aliasName, seedFromDefault }) {
+export function setupCode({ name, configDir, aliasName, seedMode = "empty", seedItems }) {
   step(`Creating Claude Code profile "${name}"`);
 
   info(`Config folder: ${pathStr(tildify(configDir))}`);
   info(`Shell alias: ${pathStr(aliasName)}`);
 
-  const created = ensureConfigDir(configDir, { seedFromDefault });
+  const created = ensureConfigDir(configDir, { seedMode, seedItems });
   if (created) {
-    if (seedFromDefault) {
-      ok(`Config folder created and seeded from ${pathStr(tildify(DEFAULT_CLAUDE_CONFIG_DIR))}.`);
-      ok("Existing skills, plugins, and MCP config carried over. Auth did not (it lives in Keychain).");
+    if (seedMode === "copy") {
+      ok(`Config folder created and copied from ${pathStr(tildify(DEFAULT_CLAUDE_CONFIG_DIR))}.`);
+      ok("Existing skills, plugins, and settings carried over. Auth did not (login lives in Keychain).");
+    } else if (seedMode === "symlink") {
+      const linked = seedItems ?? shareableItemsIn();
+      ok(`Config folder created with ${linked.length} symlink(s) into ${pathStr(tildify(DEFAULT_CLAUDE_CONFIG_DIR))}.`);
+      ok("Linked items stay in sync with your root profile. Auth was not linked (it lives in Keychain).");
     } else {
       ok("Config folder created (empty).");
     }

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -12,7 +12,7 @@
 //   3. Confirmation, execution, and printed next steps
 
 import path from "node:path";
-import { input, select, confirm } from "@inquirer/prompts";
+import { input, select, confirm, checkbox } from "@inquirer/prompts";
 import {
   HOME,
   ok,
@@ -42,6 +42,7 @@ import {
   defaultAliasNameFor,
   DEFAULT_CLAUDE_CONFIG_DIR,
   setupCode,
+  shareableItemsIn,
 } from "../code.js";
 import { detectShell, rcPathForShell } from "../shell.js";
 
@@ -321,25 +322,95 @@ async function askCodeQuestions(name) {
   });
 
   // Seeding decision: only offered if a default ~/.claude exists.
-  let seedFromDefault = false;
+  let seedMode = "empty";
+  let seedItems;
   if (fileExists(DEFAULT_CLAUDE_CONFIG_DIR)) {
     explain(`
-      You already have a ~/.claude config from your existing Claude Code
-      install. We can copy its contents into the new profile's folder so
-      that any skills, plugins, MCP servers, or slash commands you've set
-      up come along for the ride.
+      Your existing ~/.claude holds the skills, plugins, slash commands, and
+      settings you've set up. This new profile can either stand on its own, or
+      stay in sync with that setup.
 
-      Authentication does NOT carry over. Claude Code stores its login in
-      macOS Keychain under a key derived from CLAUDE_CONFIG_DIR, which is
-      different for the new profile. You'll sign in fresh on first launch.
+      Your login is always separate regardless of what you pick here. Claude
+      Code keys auth to CLAUDE_CONFIG_DIR, so you'll sign in fresh on this
+      profile and your main account is never touched. (Note: if you keep an
+      API key or token inside settings.json or an MCP config, sharing that
+      file also shares the key — the login itself is what's guaranteed
+      separate.)
     `);
-    seedFromDefault = await confirm({
-      message: "Copy your existing ~/.claude into the new profile? (recommended)",
-      default: true,
+
+    const kind = await select({
+      message: "What kind of Claude Code profile is this?",
+      choices: [
+        {
+          name: "Isolated — its own independent config",
+          value: "isolated",
+          description:
+            "Nothing is shared. Skills, settings, and sessions you change here never affect your main ~/.claude, and changes there never reach here. Best for a truly separate account or a sandbox.",
+        },
+        {
+          name: "Synchronized — share selected data with ~/.claude",
+          value: "synced",
+          description:
+            "Pick items to symlink. They stay live-shared with your main profile, so e.g. installing a skill or plugin in one shows up in both. Auth/identity files are never shared.",
+        },
+      ],
+      default: "isolated",
     });
+
+    if (kind === "isolated") {
+      seedMode = await select({
+        message: "Start this isolated profile from your current setup?",
+        choices: [
+          {
+            name: "Copy my current ~/.claude (skills, plugins, settings, etc.)",
+            value: "copy",
+            description:
+              "A one-time snapshot copied in now. It's fully independent afterwards — later changes to ~/.claude won't propagate. Auth is stripped from the copy.",
+          },
+          {
+            name: "Start empty",
+            value: "empty",
+            description:
+              "A blank profile. You'll add skills, plugins, and settings yourself.",
+          },
+        ],
+        default: "copy",
+      });
+    } else {
+      // Synchronized: symlink a chosen subset of safe items.
+      const available = shareableItemsIn(DEFAULT_CLAUDE_CONFIG_DIR);
+      if (available.length === 0) {
+        warn("None of the safe shareable items were found in ~/.claude. Starting empty instead.");
+        seedMode = "empty";
+      } else {
+        // Pre-check config-like items (behavior/setup you'd want shared).
+        // Leave conversation/history data (projects, sessions, transcripts,
+        // history.jsonl) unchecked by default so a "separate" profile doesn't
+        // silently inherit your whole corpus — the user can opt in per item.
+        const CHECKED_BY_DEFAULT = new Set([
+          "skills", "plugins", "agents", "commands", "rules", "hooks",
+          "settings.json", "settings.local.json", "CLAUDE.md",
+          ".omc", ".omc-config.json", ".omc-version.json", ".ponytail-active",
+        ]);
+        seedItems = await checkbox({
+          message: "Select data to keep in sync (symlinked — auth is never listed):",
+          choices: available.map((item) => ({
+            name: item,
+            value: item,
+            checked: CHECKED_BY_DEFAULT.has(item),
+          })),
+        });
+        if (seedItems.length === 0) {
+          warn("Nothing selected. Starting empty instead.");
+          seedMode = "empty";
+        } else {
+          seedMode = "symlink";
+        }
+      }
+    }
   }
 
-  return { name, configDir, aliasName, seedFromDefault };
+  return { name, configDir, aliasName, seedMode, seedItems };
 }
 
 // ===========================================================================
@@ -360,9 +431,15 @@ function printPlan({ name, desktopConfig, codeConfig }) {
     console.log("  Claude Code:");
     console.log(`    Config folder: ${pathStr(tildify(codeConfig.configDir))}`);
     console.log(`    Shell alias: ${pathStr(codeConfig.aliasName)}`);
-    console.log(
-      `    Seed from existing ~/.claude: ${codeConfig.seedFromDefault ? "yes" : "no"}\n`
-    );
+    if (codeConfig.seedMode === "copy") {
+      console.log(`    Profile: isolated, copied from ~/.claude (snapshot)\n`);
+    } else if (codeConfig.seedMode === "symlink") {
+      console.log(
+        `    Profile: synchronized with ~/.claude — ${codeConfig.seedItems.length} symlink(s) (${codeConfig.seedItems.join(", ")})\n`
+      );
+    } else {
+      console.log(`    Profile: isolated, empty\n`);
+    }
   }
 }
 

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -122,3 +122,103 @@ test("writeAliases creates a managed block when none exists, and replaces it on 
   assert.equal(startMatches.length, 1);
   assert.equal(endMatches.length, 1);
 });
+
+// ---------------------------------------------------------------------------
+// code.js - safe symlink seeding
+// ---------------------------------------------------------------------------
+
+import {
+  isShareable,
+  shareableItemsIn,
+  symlinkSelected,
+} from "../src/code.js";
+
+test("isShareable: excludes auth/identity + noise, allows arbitrary user items", () => {
+  // auth / identity — always excluded (exact names and by pattern)
+  for (const n of [".claude.json", ".credentials.json", "credentials.json",
+    "auth.json", "my-token.txt", "api-secret", "server.pem", "id.key"]) {
+    assert.equal(isShareable(n), false, `expected ${n} excluded`);
+  }
+  // cache / instance noise — excluded
+  for (const n of ["statsig", "cache", "paste-cache", ".DS_Store",
+    "foo-cache.json", "usage-stats.json", "daemon-1", "run.log"]) {
+    assert.equal(isShareable(n), false, `expected ${n} excluded`);
+  }
+  // path traversal / bad names — excluded (blocklist can't be tricked)
+  for (const n of ["..", ".", "../x", "a/b", "a\\b", ""]) {
+    assert.equal(isShareable(n), false, `expected ${JSON.stringify(n)} excluded`);
+  }
+  // known-safe AND arbitrary user content — allowed (blocklist lets extras through)
+  for (const n of ["skills", "plugins", "settings.json", "commands", "agents",
+    "rules", "my-custom-dir", "notes.md"]) {
+    assert.equal(isShareable(n), true, `expected ${n} shareable`);
+  }
+});
+
+test("shareableItemsIn lists everything present except blocked items", () => {
+  const src = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-src-"));
+  fs.mkdirSync(path.join(src, "skills"));
+  fs.mkdirSync(path.join(src, "my-custom-dir")); // user's own -> shared
+  fs.writeFileSync(path.join(src, "settings.json"), "{}");
+  fs.writeFileSync(path.join(src, ".credentials.json"), "secret"); // blocked
+  fs.writeFileSync(path.join(src, ".claude.json"), "{}"); // blocked
+
+  const items = shareableItemsIn(src);
+  assert.ok(items.includes("skills"));
+  assert.ok(items.includes("my-custom-dir"));
+  assert.ok(items.includes("settings.json"));
+  assert.ok(!items.includes(".credentials.json"));
+  assert.ok(!items.includes(".claude.json"));
+});
+
+test("symlinkSelected links safe items, resolves to real target, REFUSES auth + traversal", () => {
+  const src = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-src-"));
+  const dst = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-dst-"));
+  fs.mkdirSync(path.join(src, "skills"));
+  fs.writeFileSync(path.join(src, "settings.json"), "{}");
+  fs.writeFileSync(path.join(src, ".credentials.json"), "secret");
+
+  const linked = symlinkSelected(
+    dst,
+    ["skills", "settings.json", ".credentials.json", "../escape"],
+    src
+  );
+
+  assert.deepEqual(linked.sort(), ["settings.json", "skills"]);
+  // link resolves to the real source (data genuinely shared, not copied)
+  assert.equal(fs.readlinkSync(path.join(dst, "skills")), path.join(src, "skills"));
+  assert.ok(fs.lstatSync(path.join(dst, "settings.json")).isSymbolicLink());
+  // auth file + traversal target must never appear
+  assert.ok(!fs.existsSync(path.join(dst, ".credentials.json")));
+  assert.ok(!fs.existsSync(path.join(dst, "escape")));
+});
+
+test("symlinkSelected never destroys a real (non-symlink) dir at the destination", () => {
+  const src = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-src-"));
+  const dst = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-dst-"));
+  fs.mkdirSync(path.join(src, "skills"));
+  // real dir with user data already sitting where the link would go
+  fs.mkdirSync(path.join(dst, "skills"));
+  fs.writeFileSync(path.join(dst, "skills", "keep.txt"), "important");
+
+  // Fails loud (EEXIST) rather than recursively deleting the real dir.
+  assert.throws(() => symlinkSelected(dst, ["skills"], src));
+  assert.equal(
+    fs.readFileSync(path.join(dst, "skills", "keep.txt"), "utf8"),
+    "important"
+  );
+});
+
+test("symlinkSelected re-links idempotently when dst already holds a symlink", () => {
+  const src = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-src-"));
+  const dst = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-dst-"));
+  const stale = fs.mkdtempSync(path.join(os.tmpdir(), "cmp-stale-"));
+  fs.mkdirSync(path.join(src, "skills"));
+  // a stale symlink from a prior run points somewhere else
+  fs.symlinkSync(stale, path.join(dst, "skills"));
+
+  // re-linking must not throw and must re-point at the real source
+  const linked = symlinkSelected(dst, ["skills"], src);
+  assert.deepEqual(linked, ["skills"]);
+  assert.equal(fs.readlinkSync(path.join(dst, "skills")), path.join(src, "skills"));
+});


### PR DESCRIPTION
## Synchronized Code profiles via safe symlink seeding

Adds a second way to seed a new Claude **Code** profile from `~/.claude`. Today `add` offers a single yes/no that does a full `cp -R` copy. This PR reframes that choice around what users actually want the profile to *be*:

- **Isolated** (default) — a standalone config. Optionally copy a one-time snapshot of `~/.claude`, or start empty. Independent thereafter.
- **Synchronized** — pick items to **symlink** back to `~/.claude`, so they stay live-shared. Install a skill or plugin under one profile and it shows up in both.

The symlink idea comes from a small shell script some of us already use to share sessions/config across profiles; this brings it into the wizard, safely.

### Why a blocklist, not an allowlist

An earlier draft used an allowlist of known-safe items. It works, but it silently drops a user's own custom directories. This PR uses a **blocklist**: everything under `~/.claude` is shareable *except* what's excluded. So custom content comes along, but auth can't leak.

The exclusion covers two classes:
- **Auth / identity** (security boundary) — `.claude.json`, `.credentials.json`, and anything matching credential/token/secret/oauth/api-key/jwt/`.env`/key patterns. Matched **unbounded on purpose**: for this class we prefer a rare false-positive (a safe file hidden from the picker) over ever sharing a credential.
- **Instance-local noise** — caches, logs, `statsig`, `daemon*`, `shell-snapshots`.

Defense in depth: the exclusion is enforced in the picker **and** re-checked at the symlink sink, so an off-list name (auth file, `../escape`) is refused even if passed directly. Copy mode is pruned to the same safe set, so neither mode can retain a token or key file. Login is always separate regardless — Claude Code keys auth to `CLAUDE_CONFIG_DIR` (Keychain on macOS).

### Changes

- `src/code.js` — `isShareable` / `shareableItemsIn` / `symlinkSelected`; blocklist (`NEVER_SHARE_EXACT` + `NEVER_SHARE_PATTERNS`); `seedMode` threaded through `ensureConfigDir` / `setupCode`. `cleanCredentialsFromDir` now also strips a copied `.claude.json`.
- `src/commands/add.js` — Isolated/Synchronized wizard with an item picker (config-like items checked by default; conversation history is opt-in).
- `test/unit.test.js` — classification, traversal refusal, real-target resolution, data-loss guard, auth refusal at the sink, idempotent relink (11 tests total).
- `README.md` — documents both seeding modes and the shared blocklist.

### Testing

`npm test` → 11/11. Verified against a real `~/.claude`: all auth/identity/cache items excluded, custom dirs included, no false positives on legitimate entries (`session-env`, `sessions`, `remote-settings.json`), and no auth leak in either mode. No new dependencies (reuses `@inquirer/prompts`' `checkbox`).

### Notes / limitations

- macOS/Linux, matching the existing Code-profile support.
- If you keep an API key inside `settings.json` or an MCP config and choose to share that file, the key travels with it — only the Keychain login is guaranteed separate. Called out in the wizard and README.
