### PR TITLE
Pass CLAUDE_CONFIG_DIR to Desktop-spawned Claude Code

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -190,7 +190,17 @@ export async function add() {
   let codeResult = null;
 
   if (desktopConfig) {
-    desktopResult = setupDesktop(desktopConfig);
+    // Hand the Code config dir to the Desktop launcher so it can export
+    // CLAUDE_CONFIG_DIR. Without this, Claude Code sessions started from
+    // inside Claude Desktop fall back to ~/.claude in every profile, and
+    // CLAUDE.md / settings.json / per-project memory merge across profiles
+    // even though Desktop itself is cleanly isolated.
+    // Undefined when the profile has no Code target — the launcher then
+    // omits --env and behaves exactly as it did before.
+    desktopResult = setupDesktop({
+      ...desktopConfig,
+      codeConfigDir: codeConfig?.configDir,
+    });
   }
   if (codeConfig) {
     codeResult = setupCode(codeConfig);

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -195,7 +195,7 @@ export async function add() {
     // inside Claude Desktop fall back to ~/.claude in every profile, and
     // CLAUDE.md / settings.json / per-project memory merge across profiles
     // even though Desktop itself is cleanly isolated.
-    // Undefined when the profile has no Code target — the launcher then
+    // Undefined when the profile has no Code target, in which case the launcher
     // omits --env and behaves exactly as it did before.
     desktopResult = setupDesktop({
       ...desktopConfig,

--- a/src/commands/rename.js
+++ b/src/commands/rename.js
@@ -266,11 +266,16 @@ export async function rename(args = []) {
     }
 
     try {
+      // Pass the (possibly renamed) Code config dir through so the rebuilt
+      // launcher keeps exporting CLAUDE_CONFIG_DIR. Omitting it here would
+      // silently drop the --env flag on rename, putting Desktop-spawned
+      // Claude Code back on the shared ~/.claude.
       compileApp({
         name: newName,
         dataDir: newDesktop.dataDir,
         appPath: newDesktop.appPath,
         claudeAppPath: profile.desktop.claudeAppPath,
+        codeConfigDir: newCode ? newCode.configDir : undefined,
       });
       copyClaudeIcon(newDesktop.appPath, profile.desktop.claudeAppPath);
       ok(`Rebuilt launcher at ${pathStr(tildify(newDesktop.appPath))}.`);

--- a/src/desktop.js
+++ b/src/desktop.js
@@ -122,12 +122,12 @@ export function buildLaunchAppleScript(dataDir, claudeAppPath, codeConfigDir) {
   // Desktop spawns: those read ~/.claude in every profile, because Desktop
   // does not set CLAUDE_CONFIG_DIR for the CLI it launches. The practical
   // effect is that CLAUDE.md, settings.json, and per-project memory MERGE
-  // across profiles even when Desktop itself is cleanly separated — which
+  // across profiles even when Desktop itself is cleanly separated, which
   // is the failure this whole tool exists to prevent.
   //
   // Verified on macOS 25.5 (2026-07-29), A/B against a control launch:
   // `open --env` sets the variable in the launched app's environment AND in
-  // the environment its child processes inherit — the exact relationship
+  // the environment its child processes inherit, which is the exact relationship
   // Claude.app has with the claude-code CLI. Passing it via --env rather
   // than launching the binary directly keeps `open -n` semantics intact,
   // which the -n comment above explains is load-bearing.

--- a/src/desktop.js
+++ b/src/desktop.js
@@ -108,7 +108,7 @@ export function ensureDataDir(dataDir) {
 
 // ---- .app bundle generation ----------------------------------------
 
-export function buildLaunchAppleScript(dataDir, claudeAppPath) {
+export function buildLaunchAppleScript(dataDir, claudeAppPath, codeConfigDir) {
   // The `open -n` flag forces a new instance even when Claude is already
   // running. Without -n, macOS would route the request to the existing
   // Claude window and ignore our --user-data-dir argument entirely.
@@ -116,11 +116,34 @@ export function buildLaunchAppleScript(dataDir, claudeAppPath) {
   // The `-a` argument takes a path or app name; we pass the explicit path
   // so this works even if there are multiple Claude.app bundles around.
   //
+  // `--env CLAUDE_CONFIG_DIR=...` closes the other half of the isolation.
+  // --user-data-dir separates Claude DESKTOP state (auth, chats, settings,
+  // MCP connectors). It does NOT separate the Claude CODE sessions that
+  // Desktop spawns: those read ~/.claude in every profile, because Desktop
+  // does not set CLAUDE_CONFIG_DIR for the CLI it launches. The practical
+  // effect is that CLAUDE.md, settings.json, and per-project memory MERGE
+  // across profiles even when Desktop itself is cleanly separated — which
+  // is the failure this whole tool exists to prevent.
+  //
+  // Verified on macOS 25.5 (2026-07-29), A/B against a control launch:
+  // `open --env` sets the variable in the launched app's environment AND in
+  // the environment its child processes inherit — the exact relationship
+  // Claude.app has with the claude-code CLI. Passing it via --env rather
+  // than launching the binary directly keeps `open -n` semantics intact,
+  // which the -n comment above explains is load-bearing.
+  //
+  // codeConfigDir is optional: when the profile has no Claude Code target,
+  // omitting it leaves Desktop-spawned Claude Code on the default ~/.claude,
+  // which is the pre-existing behaviour.
+  //
   // We escape any single quotes in the paths defensively, though Library
   // and Applications paths shouldn't contain them in practice.
   const safeApp = claudeAppPath.replace(/'/g, "'\\''");
   const safeDir = dataDir.replace(/'/g, "'\\''");
-  return `do shell script "open -n -a '${safeApp}' --args --user-data-dir='${safeDir}' > /dev/null 2>&1 &"`;
+  const envFlag = codeConfigDir
+    ? `--env 'CLAUDE_CONFIG_DIR=${codeConfigDir.replace(/'/g, "'\\''")}' `
+    : "";
+  return `do shell script "open -n -a '${safeApp}' ${envFlag}--args --user-data-dir='${safeDir}' > /dev/null 2>&1 &"`;
 }
 
 // PlistBuddy is the standard tool for editing .plist files on macOS. Always
@@ -199,11 +222,11 @@ export function stripQuarantine(appPath) {
   }
 }
 
-export function compileApp({ name, dataDir, appPath, claudeAppPath }) {
+export function compileApp({ name, dataDir, appPath, claudeAppPath, codeConfigDir }) {
   // We write the AppleScript to a temp file then run `osacompile` to turn
   // it into a real .app bundle. osacompile is part of macOS, no install
   // needed.
-  const script = buildLaunchAppleScript(dataDir, claudeAppPath);
+  const script = buildLaunchAppleScript(dataDir, claudeAppPath, codeConfigDir);
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cp-"));
   const scriptPath = path.join(tmpDir, "launcher.applescript");
   fs.writeFileSync(scriptPath, script, "utf8");
@@ -279,7 +302,7 @@ export function copyClaudeIcon(appPath, claudeAppPath) {
 
 // ---- Top-level orchestration -------------------------------------
 
-export function setupDesktop({ name, dataDir, appPath, claudeAppPath, applyIcon }) {
+export function setupDesktop({ name, dataDir, appPath, claudeAppPath, applyIcon, codeConfigDir }) {
   // Wraps the whole setup. Returns a summary the wizard can save to the
   // registry and print to the user.
   step(`Creating Claude Desktop profile "${name}"`);
@@ -287,11 +310,12 @@ export function setupDesktop({ name, dataDir, appPath, claudeAppPath, applyIcon 
   info(`Data folder: ${pathStr(tildify(dataDir))}`);
   info(`Launcher app: ${pathStr(tildify(appPath))}`);
   info(`Claude.app source: ${pathStr(claudeAppPath)}`);
+  if (codeConfigDir) info(`Code config for Desktop-spawned Claude Code: ${pathStr(tildify(codeConfigDir))}`);
 
   ensureDataDir(dataDir);
   ok("Data folder ready.");
 
-  compileApp({ name, dataDir, appPath, claudeAppPath });
+  compileApp({ name, dataDir, appPath, claudeAppPath, codeConfigDir });
   ok("Launcher .app compiled.");
 
   if (applyIcon) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -419,3 +419,39 @@ test("writeAliases with an empty list removes the managed block entirely", async
   assert.ok(!content.includes("# <<< claude-multiprofile <<<"), "end marker gone");
   assert.equal(readManagedAliases("zsh").length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// desktop.js - launcher AppleScript, including CLAUDE_CONFIG_DIR injection
+// ---------------------------------------------------------------------------
+
+import { buildLaunchAppleScript } from "../src/desktop.js";
+
+const APP = "/Applications/Claude.app";
+const DIR = "/Users/x/Library/Application Support/Claude-WORK";
+
+test("buildLaunchAppleScript: without a code config dir, no --env is emitted (upstream behaviour)", () => {
+  const s = buildLaunchAppleScript(DIR, APP);
+  assert.ok(s.includes("open -n -a '/Applications/Claude.app'"));
+  assert.ok(s.includes(`--user-data-dir='${DIR}'`));
+  assert.ok(!s.includes("--env"), "no --env when the profile has no Code target");
+});
+
+test("buildLaunchAppleScript: with a code config dir, --env precedes --args", () => {
+  const s = buildLaunchAppleScript(DIR, APP, "/Users/x/.claude-work");
+  assert.ok(s.includes("--env 'CLAUDE_CONFIG_DIR=/Users/x/.claude-work'"));
+  // `open` requires --env BEFORE --args; everything after --args goes to argv.
+  assert.ok(
+    s.indexOf("--env") < s.indexOf("--args"),
+    "--env must come before --args or open passes it to the app as an argument"
+  );
+});
+
+test("buildLaunchAppleScript: single quotes in the config dir are escaped", () => {
+  const s = buildLaunchAppleScript(DIR, APP, "/Users/o'brien/.claude-work");
+  assert.ok(s.includes("'\\''"), "apostrophe is shell-escaped, not left to break the quoting");
+});
+
+test("buildLaunchAppleScript: an empty code config dir is treated as absent", () => {
+  assert.ok(!buildLaunchAppleScript(DIR, APP, "").includes("--env"));
+  assert.ok(!buildLaunchAppleScript(DIR, APP, undefined).includes("--env"));
+});


### PR DESCRIPTION

## The gap

`--user-data-dir` isolates Claude **Desktop** – auth, chats, settings, MCP connectors. It
does **not** isolate the Claude **Code** sessions that Desktop spawns. Those read
`~/.claude` in every profile, because Desktop sets no `CLAUDE_CONFIG_DIR` for the CLI it
launches.

The practical effect is that `CLAUDE.md`, `settings.json`, and per-project memory **merge
across profiles** even when Desktop itself is cleanly separated – which is the failure this
tool exists to prevent. The README's "share skills across profiles" tip hints at the
boundary; this is the other side of it.

## Observed with the tool installed and a profile active

**11 files written into `~/.claude/projects/` while the second profile's Desktop instance
was running**, over a 55-minute window, with nothing written into that profile's own config
directory. The profile was correctly created, correctly launched, and Desktop's own state
was cleanly isolated. The Claude Code side simply was not covered.

That is the whole of the bug report, and it is what this PR fixes.

## The fix

`buildLaunchAppleScript` gains an optional `codeConfigDir` and emits
`--env 'CLAUDE_CONFIG_DIR=…'`:

```
open -n -a '/Applications/Claude.app' \
  --env 'CLAUDE_CONFIG_DIR=/Users/x/.claude-work' \
  --args --user-data-dir='/Users/x/Library/Application Support/Claude-WORK'
```

`add.js` passes `codeConfig?.configDir` through to `setupDesktop`.

**Why `open --env` rather than invoking the binary directly:** it preserves `open -n`
semantics, which the existing comment correctly identifies as load-bearing. Without `-n`,
macOS routes to the running window and ignores `--user-data-dir` entirely.

## Verification

Verified on macOS 25.5, A/B against a control launch. `open --env` sets the variable in the
launched app's environment **and** in the environment its child processes inherit – the
exact relationship `Claude.app` has with the claude-code CLI.

Then end to end, with two profiles running side by side:

```
pid 98590  Claude-WORK             CLAUDE_CONFIG_DIR=/Users/x/.claude-work
pid  6302  its claude-code child   CLAUDE_CONFIG_DIR=/Users/x/.claude-work
pid 24249  Claude (default)        CLAUDE_CONFIG_DIR=/Users/x/.claude
```

The second profile's value is not the default, so it cannot be explained by a fallback.
Transcripts now land in the correct profile's `projects/` directory; before the change that
count was always zero.

## Notes for review

- **Backwards compatible.** `codeConfigDir` is optional. A Desktop-only profile emits no
  `--env` and behaves exactly as before.
- **`--env` must precede `--args`.** Everything after `--args` goes to the app's argv, so
  the wrong order launches the app perfectly and silently isolates nothing. There is a test
  asserting the ordering for that reason.
- **4 new tests, 10/10 passing** – the no-env case, the env case with an ordering assertion,
  single-quote escaping, and empty/undefined treated as absent.
- Existing profiles keep their old launcher until `add` is re-run for them. A `repair`-style
  rebuild might be worth considering separately.

Thanks for the tool – the `-n` comment in `desktop.js` saved me from taking the
direct-binary route, which would have broken new-instance behaviour.
